### PR TITLE
Add Nano X side loading note

### DIFF
--- a/_docs/nano-app/quickstart.md
+++ b/_docs/nano-app/quickstart.md
@@ -55,6 +55,10 @@ make
 make load
 ```
 
+<!--  -->
+{% include alert.html style="primary" text="The <b>Nano X</b> does not support side loading, therefore you must use the device emulator Speculos for loading to work." %}
+<!--  -->
+
 This video shows the loading and the public key verification (00:25") and the application hash verification (00:44").
 It ends showing the Boilerplate app is correctly installed on the Nano.
 


### PR DESCRIPTION
I tried to load the boilerplate app on my nano x device and got an unknown status word (0x69d5). After asking about the status word in the Ledger slack I got the following response

```
Edouard-ledger  13 hours ago
It's impossible to side-load apps on a Nanox, you should use speculos exclusively for that purpose
```

As this is currently not described in the documentation, I feel it is worth adding a note.