### PR TITLE
[add] Ethereum SDK must be explicitely cloned when creating a plugin app

### DIFF
--- a/_docs/dapp/nano-plugin/boilerplate-plugin.md
+++ b/_docs/dapp/nano-plugin/boilerplate-plugin.md
@@ -14,13 +14,27 @@ You can follow it best by forking the repository [https://github.com/LedgerHQ/ap
 
 ```sh
 cd ..
-git clone --recurse-submodules https://github.com/LedgerHQ/app-plugin-boilerplate  
+git clone https://github.com/LedgerHQ/app-plugin-boilerplate
 ```
+
+We will need the Ethereum SDK to build our plugin. It can be cloned anywhere, but it is easier to add it directly inside the `app-plugin-boilerplate` directory:
+
+```sh
+cd app-plugin-boilerplate/
+git clone https://github.com/LedgerHQ/ethereum-plugin-sdk
+```
+
+<!--  -->
+{% include alert.html style="important" text="The SDk repository defaults on branch \"master\", which is synchronized with the Ethereum application latest stable version.
+
+If your want to work on a newer but unstable version, checkout the \"develop\" branch.
+" %}
+<!--  -->
 
 ## What's what
 
 There is no need to build it right now, only after adding tests. For now, in `app-plugin-boilerplate/` there are these folders:
-- `ethereum-plugin-sdk`: This submodule (read sub-repo) contains information shared by the Ethereum app and your plugin, such as structure definitions, utility functions, etc.
+- `ethereum-plugin-sdk`: This repository contains information shared by the Ethereum app and your plugin, such as structure definitions, utility functions, etc.
 - `icons`: plugin icons as displayed on the device. We will get to it later, but you can read about it [here](https://developers.ledger.com/docs/nano-app/design-requirements/).
 - `src`: the actual source code (in C).
 - `tests/`: the test folder (using the js Testing Framework).

--- a/_docs/dapp/nano-plugin/environment-setup.md
+++ b/_docs/dapp/nano-plugin/environment-setup.md
@@ -84,7 +84,7 @@ In the first compilation, you may come across:
 2. `continue connecting` messages: type `yes`.
 3. a few `gcc` or `clang` warnings about the C code. This is (unfortunately) expected.
 
-If everything goes, you should end with:
+If everything goes well, you should end with:
 ```sh
 ...
 [LINK] bin/app.elf


### PR DESCRIPTION
Latter modification on app-boilerplate-plugin removed the SDK as as submodule from the plugin repo.
Now the SDK must be cloned explicitely.