### PR TITLE
Refine the test-dataset into latest "integration tests" evolution

### DIFF
--- a/_docs/coin/bridge-test.md
+++ b/_docs/coin/bridge-test.md
@@ -15,7 +15,6 @@ This page describes how tests are implemented in order to test live-common bridg
 - Transaction status
 - Account synchronisation
 
-
 The approach is to test transactions and accounts synchronisation for the different currencies supported in Ledger Live. The transactions are not Broadcasted to the blockchain. We just verify that the bridge behave properly regarding to a tx inputs (recipient address, amount, fee…).
 
 We record the synchronisation state to produce an expected output (Number of accounts, account balance, fresh address…).
@@ -25,7 +24,9 @@ For a specific currency, the seed used needs to be frozen, it’s mean that no n
 By doing so we can ensure that the account synchronisation and the transaction status will always provide the same results.
 
 <!--  -->
+
 {% include alert.html style="important" text="<b>Prerequisite</b> - Your computer is expected to have been set up accordingly. Please follow the following guides for this purpose:<br>
+
 <div> <ul>
 <li><a href='https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/2610659678/Ledger+Live+Common#ledger-live-cli-setup' class='alert-link'>ledger-live CLI</a></li>
 <li>Physical Nano device or an <a href='https://developers.ledger.com/docs/speculos/installation/build' class='alert-link'>emulated device with Speculos</a></li>
@@ -48,8 +49,7 @@ ledger-live generateTestScanAccounts -c <currency>    #Record the APDUs exchange
 
 Then copy the result in:
 
-`ledger-live/libs/ledger-live-common/src/families/<currency>/datasets/<currency>.scanAccounts.1.js`
-
+`ledger-live/libs/ledger-live-common/src/families/<currency>/datasets/<currency>.scanAccounts.1.ts`
 
 ### Send (get transaction status)
 
@@ -65,7 +65,7 @@ ledger-live generateTestTransaction -c bitcoin -i 1 -s 'native_segwit' --recipie
 
 Then copy the result in:
 
-`ledger-live/libs/ledger-live-common/src/families/<currency>/datasets/<currency>.js` or `ledger-live/libs/ledger-live-common/src/families/<currency>/test-dataset.js`
+`ledger-live/libs/ledger-live-common/src/families/<currency>/datasets/<currency>.ts` or `ledger-live/libs/ledger-live-common/src/families/<currency>/bridge.integration.test.ts`
 
 ```js
 const dataset: CurrenciesData<Transaction> = {
@@ -80,7 +80,7 @@ const dataset: CurrenciesData<Transaction> = {
             recipient: "bc1qqmxqdrkxgx6swrvjl9l2e6szvvkg45all5u4fl",
             amount: "997",
             feePerByte: "1",
-            networkInfo
+            networkInfo,
           }),
           expectedStatus: {
             amount: BigNumber("997"),
@@ -88,15 +88,14 @@ const dataset: CurrenciesData<Transaction> = {
             totalSpent: BigNumber("1247"),
             errors: {},
             warnings: {
-              feeTooHigh: new FeeTooHigh()
-            }
-          }
-        }
+              feeTooHigh: new FeeTooHigh(),
+            },
+          },
+        },
       ],
-// Account that will be use to send funds from
+      // Account that will be use to send funds from
       raw: {
-        id:
-          "libcore:1:bitcoin:xpub6BuPWhjLqutPV8SF4RMrrn8c3t7uBZbz4CBbThpbg9GYjqRMncra9mjgSfWSK7uMDz37hhzJ8wvkbDDQQJt6VgwLoszvmPiSBtLA1bPLLSn:",
+        id: "libcore:1:bitcoin:xpub6BuPWhjLqutPV8SF4RMrrn8c3t7uBZbz4CBbThpbg9GYjqRMncra9mjgSfWSK7uMDz37hhzJ8wvkbDDQQJt6VgwLoszvmPiSBtLA1bPLLSn:",
         seedIdentifier:
           "041caa3a42db5bdd125b2530c47cfbe829539b5a20a5562ec839d241c67d1862f2980d26ebffee25e4f924410c3316b397f34bd572543e72c59a7569ef9032f498",
         name: "Bitcoin 1 (legacy)",
@@ -107,8 +106,8 @@ const dataset: CurrenciesData<Transaction> = {
         freshAddresses: [
           {
             address: "17gPmBH8b6UkvSmxMfVjuLNAqzgAroiPSe",
-            derivationPath: "44'/0'/0'/0/59"
-          }
+            derivationPath: "44'/0'/0'/0/59",
+          },
         ],
         pendingOperations: [],
         operations: [],
@@ -117,33 +116,25 @@ const dataset: CurrenciesData<Transaction> = {
         balance: "2757",
         blockHeight: 0,
         lastSyncDate: "",
-        xpub:
-          "xpub6BuPWhjLqutPV8SF4RMrrn8c3t7uBZbz4CBbThpbg9GYjqRMncra9mjgSfWSK7uMDz37hhzJ8wvkbDDQQJt6VgwLoszvmPiSBtLA1bPLLSn"
-      }
-    }
-  ]
+        xpub: "xpub6BuPWhjLqutPV8SF4RMrrn8c3t7uBZbz4CBbThpbg9GYjqRMncra9mjgSfWSK7uMDz37hhzJ8wvkbDDQQJt6VgwLoszvmPiSBtLA1bPLLSn",
+      },
+    },
+  ],
 };
 ```
 
-For some currencies, more specific tests are specified in: `ledger-live/libs/ledger-live-common/src/families/<currency>/test-specifics.js`
-
+More specific tests can be written in `ledger-live/libs/ledger-live-common/src/families/<currency>/bridge.integration.test.ts`
 
 After adding or modify a test you must run from the root of `ledger-live`:
+
 ```sh
 pnpm build:cli
 ```
 
-
 **Record new outputs**:
 
-The following command will produce snapshots used as expected results for the tests.
-```sh
-pnpm common jest test -u
-```
-
-**Run tests**:
+When running the integration tests, new snapshots will be generated that you can commit as expected results for the tests.
 
 ```sh
-pnpm common jest test -t <currency>   #specific currency
-pnpm common jest test                 #all
+pnpm common ci-test-integration <family>
 ```

--- a/_docs/coin/live-common.md
+++ b/_docs/coin/live-common.md
@@ -45,7 +45,7 @@ All integrated coins are implemented in a `libs/ledger-live-common/src/families`
 ### Installation
 
 - Fork and clone the `ledger-live` repository [https://github.com/LedgerHQ/ledger-live](https://github.com/LedgerHQ/ledger-live)
-- `cd ledger-live` 
+- `cd ledger-live`
 - Install with `pnpm i`
 
 ## Structure
@@ -74,12 +74,13 @@ Here is a typical family folder structure (TS integration):
 ├── react.ts
 ├── specs.ts
 ├── speculos-deviceActions.ts
-├── test-dataset.ts
+├── bridge.integration.test.ts
 ├── test-specifics.ts
 └── types.ts
 ```
 
 <!--  -->
-{% include alert.html style="note" text="You can refer to existing implementations to complete given examples, like <a href='https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common/src/families/polkadot'>Polkadot integration</a>" %}
-<!--  -->
 
+{% include alert.html style="note" text="You can refer to existing implementations to complete given examples, like <a href='https://github.com/LedgerHQ/ledger-live/tree/develop/libs/ledger-live-common/src/families/polkadot'>Polkadot integration</a>" %}
+
+<!--  -->


### PR DESCRIPTION
This documentation updates covers the changes introduced by https://github.com/LedgerHQ/ledger-live/pull/414 (see that other PR to see exactly the technical impact)

TLDR: the former files "test-dataset.ts" + "test-specifics.ts" + "bridge.test.ts" are all replaced by one test file "bridge.integration.test.ts"