### PR TITLE
Fix UI bug in exchange/openapi files

### DIFF
--- a/public/exchange/openapi/buy-provider-openapi.yml
+++ b/public/exchange/openapi/buy-provider-openapi.yml
@@ -17,6 +17,7 @@ paths:
             - "coutriesCapabilities.[].country": available at the Alpha-2 standard (ISO3166),
             - "coutriesCapabilities.[].paymentMethods.[].name": Available payment method, valid values : visa, mastercard, creditcard, pix, mobikwik, easypay, astropay, upibanktransfer, sofort, bancontact, giropay, maestro, googlepay, applepay, paypal, sepa, ach, fasterpayments, easybank, bank, gbpbank, eps, ideal, other,
             - "coutriesCapabilities.[].paymentMethods.[].successRate": percentage of success of the transaction.
+          x-summary: OK
           content:
             application/json:
               schema:
@@ -121,6 +122,7 @@ paths:
            \ currency of the buy,\n- \"to\": crypto currency of the buy,\n- \"amount\"\
            : fiat amount,\n- \"cryptoAmount\": crypto amount the user will have,\
            \ must include all the fees.\n"
+         x-summary: OK
           content:
             application/json:
               schema:
@@ -158,6 +160,7 @@ paths:
             - "chainId" : for EVMs only, chain id of the blockchain, 1 for ethereum, 137 for polygon... See https://chainlist.org/
             - "contract" : mapped only if type is token, the contract address of the token.
             blockchain OR chainId should be defined. If chainId is defined, blockchain field is ignored.
+          x-summary: OK
           content:
             application/json:
               schema:

--- a/public/exchange/openapi/buy-provider-openapi.yml
+++ b/public/exchange/openapi/buy-provider-openapi.yml
@@ -122,7 +122,7 @@ paths:
            \ currency of the buy,\n- \"to\": crypto currency of the buy,\n- \"amount\"\
            : fiat amount,\n- \"cryptoAmount\": crypto amount the user will have,\
            \ must include all the fees.\n"
-         x-summary: OK
+          x-summary: OK
           content:
             application/json:
               schema:

--- a/public/exchange/openapi/sell-provider-openapi.yml
+++ b/public/exchange/openapi/sell-provider-openapi.yml
@@ -16,6 +16,7 @@ paths:
             - cryptoCurrencyCapabilities.[].maxAmount: Maximum amount of crypto the user can sell
             - "countriesCapabilities.[].country": available at the Alpha-2 standard (ISO3166),
             - "countriesCapabilities.[].paymentMethods.[].name": Available payment method, valid values : visa, mastercard, creditcard, sepa, bank, other
+          x-summary: OK
           content:
             application/json:
               schema:
@@ -109,6 +110,7 @@ paths:
             - "paymentMethod: method used to pay the user,
             - "cryptoAmount": cryptocurrency amount to sell,
             - "fiatAmount": fiat amount the user expects to receive (after all fees have been substracted),
+          x-summary: OK
           content:
             application/json:
               schema:
@@ -146,6 +148,7 @@ paths:
             - "chainId" : for EVMs only, chain id of the blockchain, 1 for ethereum, 137 for polygon... See https://chainlist.org/
             - "contract" : mapped only if type is token, the contract address of the token.
             blockchain OR chainId should be defined. If chainId is defined, blockchain field is ignored.
+          x-summary: OK
           content:
             application/json:
               schema:

--- a/public/exchange/openapi/swap-provider-openapi.yml
+++ b/public/exchange/openapi/swap-provider-openapi.yml
@@ -17,6 +17,7 @@ paths:
             - "chainId" : for EVMs only, chain id of the blockchain, 1 for ethereum, 137 for polygon... See https://chainlist.org/
             - "contract" : mapped only if type is token, the contract address of the token.
             blockchain OR chainId should be defined. If chainId is defined, blockchain field is ignored.
+          x-summary: OK
           content:
             application/json:
               schema:
@@ -39,6 +40,7 @@ paths:
       responses:
         "200":
           description: Array of supported swap pairs.
+          x-summary: OK
           content:
             application/json:
               schema:
@@ -69,6 +71,7 @@ paths:
       responses:
         "200":
           description: TODO
+          x-summary: OK
           content:
             application/json:
               schema:
@@ -96,6 +99,7 @@ paths:
       responses:
         "200":
           description: Status of an executed swap transaction
+          x-summary: OK
           content:
             application/json:
               schema:
@@ -121,6 +125,7 @@ paths:
       responses:
         "200":
           description: SwapId with flatten JWS `https://www.rfc-editor.org/rfc/rfc7515#section-7.2.2`
+          x-summary: OK
           content:
             application/json:
               schema:


### PR DESCRIPTION
Fixed a bug where the description that were too long wold'nt display correctly. 
Fixed by adding the extension `x-summary: OK` to the description fields in the openapi yaml files. 
![image](https://github.com/LedgerHQ/developer-portal/assets/85870064/e7e2f533-38a1-42ca-b52f-c709a523702e)
