### PR TITLE
Typo fix and A-Z sort of useCapabilities docs

### DIFF
--- a/pages/APIs/wallet-api/react/hooks/useCapabilities.mdx
+++ b/pages/APIs/wallet-api/react/hooks/useCapabilities.mdx
@@ -41,7 +41,7 @@ In this example:
 
 ### Understanding the Response
 
-Here is an example of a partial response from the `useCurrencies` hook:
+Here is an example of a partial response from the `useCapabilities` hook:
 
 ```json
 [

--- a/pages/APIs/wallet-api/react/hooks/useCapabilities.mdx
+++ b/pages/APIs/wallet-api/react/hooks/useCapabilities.mdx
@@ -45,24 +45,24 @@ Here is an example of a partial response from the `useCurrencies` hook:
 
 ```json
 [
-  'account.request', 
+  'account.list', 
   'account.receive', 
+  'account.request', 
+  'bitcoin.getXPub', 
+  'currency.list', 
+  'device.close', 
+  'device.exchange', 
+  'device.transport', 
+  'exchange.complete', 
+  'exchange.start', 
   'message.sign', 
   'storage.get', 
   'storage.set', 
   'transaction.sign', 
   'transaction.signAndBroadcast', 
-  'device.transport', 
-  'device.exchange', 
-  'device.close', 
-  'bitcoin.getXPub', 
-  'exchange.start', 
-  'exchange.complete', 
-  'account.list', 
-  'currency.list', 
   'wallet.capabilities', 
   'wallet.info', 
-  'wallet.userId'
+  'wallet.userId',
 ]
 ```
 


### PR DESCRIPTION
I noticed a couple of issues in the useCapabilities docs

See: https://developers.ledger.com/APIs/wallet-api/react/hooks/useCapabilities#understanding-the-response

1. It would be easier to read the list if sorted A-Z
2. Is there a typo ~useCurrencies~ _useCapabilities_