### PR TITLE
docs: fix current dApp browser manifest example

### DIFF
--- a/pages/docs/discover/dapp-browser/manifest.mdx
+++ b/pages/docs/discover/dapp-browser/manifest.mdx
@@ -26,65 +26,67 @@ Go to the **Settings** -> **Developer** section, and click on **Load Platform Ma
 
 ```json copy
 {
-    "id": "lido",
-    "name": "Lido",
-    "url": "https://dapp-browser.apps.ledger.com",
-    "params": {
-      "dappUrl": "https://stake.lido.fi/?embed=true",
-      "nanoApp": "Lido",
-      "dappName": "Lido",
-      "networks": [
-        {
-          "currency": "ethereum",
-          "chainID": 1,
-          "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/xxx"
-        }
-      ]
-    }
-    "homepageUrl": "https://lido.fi/",
-    "icon": "https://cdn.live.ledger.com/icons/platform/lido.png",
-    "platform": "all",
-    "apiVersion": "0.0.1",
-    "manifestVersion": "1",
-    "branch": "stable",
-    "categories": [
-      "staking",
-      "defi"
-    ],
-    "currencies": [
-      "ethereum"
-    ],
-    "content": {
-      "shortDescription": {
-        "en": "Stake your ETH with Lido to earn daily staking rewards."
-      },
-      "description": {
-        "en": "Stake your ETH with Lido to earn daily staking rewards."
+  "id": "lido",
+  "name": "Lido",
+  "url": "https://dapp-browser.apps.ledger.com/v2/",
+  "params": {
+    "dappUrl": "https://stake.lido.fi/?embed=true",
+    "nanoApp": "Lido",
+    "dappName": "Lido",
+    "networks": [
+      {
+        "currency": "ethereum",
+        "chainID": 1,
+        "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/xxx"
       }
-    },
-    "permissions": [],
-    "domains": [
-      "https://*"
     ]
-  }
+  },
+  "homepageUrl": "https://lido.fi/",
+  "icon": "https://cdn.live.ledger.com/icons/platform/lido.png",
+  "platform": "all",
+  "apiVersion": "^2.0.0",
+  "manifestVersion": "1",
+  "branch": "stable",
+  "categories": ["staking", "defi"],
+  "currencies": ["ethereum"],
+  "content": {
+    "shortDescription": {
+      "en": "Stake your ETH with Lido to earn daily staking rewards."
+    },
+    "description": {
+      "en": "Stake your ETH with Lido to earn daily staking rewards."
+    }
+  },
+  "permissions": [
+    "account.list",
+    "account.request",
+    "currency.list",
+    "message.sign",
+    "transaction.sign",
+    "transaction.signAndBroadcast",
+    "wallet.info",
+    "wallet.userId"
+  ],
+  "domains": ["https://"]
+}
 ```
 
 Here is the list of the mandatory fields required in your Manifest file:
 
-|  Field            |      Description    |  Type   |
-|-------------------|---------------------|---------|
-| `id`              | The identification of your application. Must be in lowercase. | String |
-| `name`            | The name of your application ("Lido" in this example).        | String |
-| `url`             | The url of the eth-dapp-browser, either running locally or at https://dapp-browser.apps.ledger.com for the production version | String |
-| `params`          | dappUrl is the URL of your DApp; nanoApp is the plugin needed to clear sign your DApp, if your DApp doesn't require a plugin set the value to Ethereum; dappName should be the same as nanoApp; networks is the list of networks supported by your DApp, Ledger Live currently only support mainnet, BSC and Polygon, the nodeURL param will be set by Ledger in prod to use your node, for testing purposes, you can replace it with your own. | String |
-| `homepageUrl`     |   This for information only. It is is non-critial. For instance, "https://lido.fi/". | String |
-| `icon`            | A link to the icon displayed in the Ledger Live Discover section. Will be hosted on Ledger CDN before being released in production. | URL |
-| `platform`        | To set the platform (desktop, mobile, iOS, Android) on which your service is available. By default, you should set the value to "all". | String |
-| `apiVersion`      | The API version, by default "0.0.1".                          | String |
-| `manifestVersion` | The manifest version. By default should be "1".               | String |
-| `branch`          | The specific branch used by Ledger to deploy the changes. Can take the values stable | experimental | debug | soon. By default, you should set it to "stable". The value “soon” will mark your app as “Coming soon” and it won’t be usable. | String |
-| `categories`      | A JSON array of metadata information about your application. For instance : ["staking","defi" ]. You can add as many as you want. It is not used for the moment but will be used for filtering in the future. | List(string) |
-| `currencies`      | A JSON array of the currency/network being used by your application. For instance ["ethereum",”polygon”]. Leave blank if the App does not require any currency. | List(string) |
-| `content`         | A description of your service. It will be displayed on the entry card of your application. Type: l18n strings. | L18n strings |
-| `permissions`     | Leave blank for now.   |   |
-| `domains`         | Leave blank for now.   |  |
+| Field             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                     | Type         |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ | ----- | ----------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `id`              | The identification of your application. Must be in lowercase.                                                                                                                                                                                                                                                                                                                                                                                   | String       |
+| `name`            | The name of your application ("Lido" in this example).                                                                                                                                                                                                                                                                                                                                                                                          | String       |
+| `url`             | The url of the eth-dapp-browser, either running locally or at https://dapp-browser.apps.ledger.com for the production version                                                                                                                                                                                                                                                                                                                   | String       |
+| `params`          | dappUrl is the URL of your DApp; nanoApp is the plugin needed to clear sign your DApp, if your DApp doesn't require a plugin set the value to Ethereum; dappName should be the same as nanoApp; networks is the list of networks supported by your DApp, Ledger Live currently only support mainnet, BSC and Polygon, the nodeURL param will be set by Ledger in prod to use your node, for testing purposes, you can replace it with your own. | String       |
+| `homepageUrl`     | This for information only. It is is non-critial. For instance, "https://lido.fi/".                                                                                                                                                                                                                                                                                                                                                              | String       |
+| `icon`            | A link to the icon displayed in the Ledger Live Discover section. Will be hosted on Ledger CDN before being released in production.                                                                                                                                                                                                                                                                                                             | URL          |
+| `platform`        | To set the platform (desktop, mobile, iOS, Android) on which your service is available. By default, you should set the value to "all".                                                                                                                                                                                                                                                                                                          | String       |
+| `apiVersion`      | The API version, by default "0.0.1".                                                                                                                                                                                                                                                                                                                                                                                                            | String       |
+| `manifestVersion` | The manifest version. By default should be "1".                                                                                                                                                                                                                                                                                                                                                                                                 | String       |
+| `branch`          | The specific branch used by Ledger to deploy the changes. Can take the values stable                                                                                                                                                                                                                                                                                                                                                            | experimental | debug | soon. By default, you should set it to "stable". The value “soon” will mark your app as “Coming soon” and it won’t be usable. | String |
+| `categories`      | A JSON array of metadata information about your application. For instance : ["staking","defi" ]. You can add as many as you want. It is not used for the moment but will be used for filtering in the future.                                                                                                                                                                                                                                   | List(string) |
+| `currencies`      | A JSON array of the currency/network being used by your application. For instance ["ethereum",”polygon”]. Leave blank if the App does not require any currency.                                                                                                                                                                                                                                                                                 | List(string) |
+| `content`         | A description of your service. It will be displayed on the entry card of your application. Type: l18n strings.                                                                                                                                                                                                                                                                                                                                  | L18n strings |
+| `permissions`     | Leave blank for now.                                                                                                                                                                                                                                                                                                                                                                                                                            |              |
+| `domains`         | Leave blank for now.                                                                                                                                                                                                                                                                                                                                                                                                                            |              |


### PR DESCRIPTION
Just updating the current dApp browser manifest example as it was not using the wallet-api and v2 of the dApp browser

Another update to the doc is in the work to explain the migration to the new native dApp support of LL