### PR TITLE
docs: add dApp browser migration doc [LIVE-9720]

### DIFF
--- a/pages/docs/discover/dapp-browser.mdx
+++ b/pages/docs/discover/dapp-browser.mdx
@@ -4,9 +4,17 @@ title: How to add a DApp with the DApp Browser?
 
 # How to add a DApp with the DApp Browser?
 
-
 To integrate a DApp with the DApp Browser, you need to:
+
 - Read the [submission guidelines](./guidelines)
 - Add a [Web3 provider](./dapp-browser/dapp-customisation/)
 - Write a [manifest](./dapp-browser/manifest/)
 - Create a [DApp Plugin](/docs/device-app/introduction/plugins/)
+
+# Already using the DApp Browser ?
+
+We are in the process of deprecating the DApp Browser.
+
+Ledger Live will now support injecting a compatible provider in the webview.
+
+You can follow our [migration documentation](./dapp-browser/migration/) to update your dApp

--- a/pages/docs/discover/dapp-browser/_meta.json
+++ b/pages/docs/discover/dapp-browser/_meta.json
@@ -1,5 +1,6 @@
-{  
-	"dapp-customisation": "Add a provider",
-	"manifest": "Write and load the manifest",
-	"plugin": "Write a plugin for clear signing"
+{
+  "dapp-customisation": "Add a provider",
+  "manifest": "Write and load the manifest",
+  "plugin": "Write a plugin for clear signing",
+  "migration": "DApp Browser migration"
 }

--- a/pages/docs/discover/dapp-browser/migration.mdx
+++ b/pages/docs/discover/dapp-browser/migration.mdx
@@ -1,0 +1,147 @@
+---
+title: DApp Browser migration
+---
+
+# DApp Browser migration
+
+We are in the process of deprecating the DApp Browser.
+
+Ledger Live will now support injecting a compatible provider in the webview.
+
+## Deprecations
+
+- [GitHub - LedgerHQ/iframe-provider](https://github.com/LedgerHQ/iframe-provider)
+- [GitHub - LedgerHQ/eth-dapp-browser](https://github.com/LedgerHQ/eth-dapp-browser)
+- `params` field in the manifest used by Ledger Live (replaced by the `dapp` field)
+
+## Changes
+
+Ledger Live will now inject the needed provider in the WebView directly avoiding the need for an iframe like the `eth-dapp-browser`
+
+The new provider is EIP 6963 compliant if there is a need for it but you can also use the injected `window.ethereum`
+
+The provider exposes a boolean `provider.isLedgerLive` to inform when you are in the Ledger Live environment, in that case we expect the dApp to auto connect using this provider, thus improving the user experience and avoid unnecessary clicks
+
+Manifest for dApps can now use the `url` field directly instead of `params.dappUrl` and must use the `dapp` field instead of the `params` for the `provider`, `networks` and `nanoApp` fields
+
+## Ledger Live supported versions
+
+- Desktop: 2.79
+- Mobile: Next release
+
+## Manifest examples
+
+```json
+{
+  "id": "metamask-test-dapp",
+  "name": "Metamask Test Dapp",
+  "private": false,
+  "url": "https://metamask.github.io/test-dapp/",
+  "dapp": {
+    "networks": [
+      {
+        "currency": "ethereum",
+        "chainID": 1,
+        "nodeURL": "https://eth-dapps.api.live.ledger.com"
+      },
+      {
+        "currency": "bsc",
+        "chainID": 56,
+        "nodeURL": "https://bsc-dataseed.binance.org/"
+      },
+      {
+        "currency": "polygon",
+        "chainID": 137,
+        "nodeURL": "https://polygon-mainnet.g.alchemy.com/v2/[your-key]"
+      },
+      {
+        "currency": "arbitrum",
+        "chainID": 42161,
+        "nodeURL": "https://arb1.arbitrum.io/rpc"
+      },
+      {
+        "currency": "optimism",
+        "chainID": 10,
+        "nodeURL": "https://mainnet.optimism.io"
+      }
+    ]
+  },
+  "homepageUrl": "https://metamask.github.io/test-dapp/",
+  "icon": "https://cdn.live.ledger.com/icons/platform/1inch.png",
+  "platforms": ["android", "ios", "desktop"],
+  "apiVersion": "^2.0.0",
+  "manifestVersion": "1",
+  "branch": "stable",
+  "categories": ["tools"],
+  "currencies": ["ethereum", "bsc", "polygon", "arbitrum", "optimism"],
+  "content": {
+    "shortDescription": {
+      "en": "Metamask Test Dapp"
+    },
+    "description": {
+      "en": "Metamask Test Dapp"
+    }
+  },
+  "permissions": [],
+  "domains": ["https://"],
+  "visibility": "complete"
+}
+```
+
+```json
+{
+  "id": "1inch-local",
+  "name": "1inch",
+  "private": false,
+  "url": "https://app.1inch.io/",
+  "dapp": {
+    "nanoApp": "1inch",
+    "networks": [
+      {
+        "currency": "ethereum",
+        "chainID": 1,
+        "nodeURL": "https://eth-dapps.api.live.ledger.com"
+      },
+      {
+        "currency": "bsc",
+        "chainID": 56,
+        "nodeURL": "https://bsc-dataseed.binance.org/"
+      },
+      {
+        "currency": "polygon",
+        "chainID": 137,
+        "nodeURL": "https://polygon-mainnet.g.alchemy.com/v2/[your-key]"
+      },
+      {
+        "currency": "arbitrum",
+        "chainID": 42161,
+        "nodeURL": "https://arb1.arbitrum.io/rpc"
+      },
+      {
+        "currency": "optimism",
+        "chainID": 10,
+        "nodeURL": "https://mainnet.optimism.io"
+      }
+    ]
+  },
+  "homepageUrl": "https://1inch.io/",
+  "icon": "https://cdn.live.ledger.com/icons/platform/1inch.png",
+  "platforms": ["android", "desktop"],
+  "apiVersion": "^2.0.0",
+  "manifestVersion": "1",
+  "branch": "stable",
+  "categories": ["swap"],
+  "currencies": ["ethereum", "bsc", "polygon", "arbitrum", "optimism"],
+  "content": {
+    "shortDescription": {
+      "en": "Exchange crypto via a Defi/DEX aggregator on Ethereum mainnet, BSC or Polygon"
+    },
+    "description": {
+      "en": "Exchange crypto via a Defi/DEX aggregator on Ethereum mainnet, BSC or Polygon"
+    }
+  },
+  "permissions": [],
+  "domains": ["https://"],
+  "visibility": "complete"
+}
+```


### PR DESCRIPTION
First pass introducing the dApp browser migration steps and changes

A second rework of this part of the documentation is needed to either remove, change or add to it for the new dApp support in LL