### PR TITLE
fix: link path to speculos

### DIFF
--- a/pages/docs/ledger-live/accounts/integration/blockchain/tests/bridge-test.mdx
+++ b/pages/docs/ledger-live/accounts/integration/blockchain/tests/bridge-test.mdx
@@ -24,7 +24,7 @@ By doing so we can ensure that the account synchronisation and the transaction s
   <b>Prerequisite</b> - Your computer is expected to have been set up accordingly. Please follow the following guides for this purpose:
   <ul>
     <li>- <a href='https://ledgerhq.atlassian.net/wiki/spaces/WALLETCO/pages/2610659678/Ledger+Live+Common#ledger-live-cli'>ledger-live CLI</a></li>
-    <li>- Physical Ledger device or an <a href='../../device-app/tools/speculos'>emulated device with Speculos</a></li>
+    <li>- Physical Ledger device or an <a href='../../../../../device-app/references/tools#speculos'>emulated device with Speculos</a></li>
   </ul>
 </Callout>
 


### PR DESCRIPTION
Fix link to Speculos on the **Live Common Bridge Test** page.

It was going to the 404 page, and now it points to this [one](https://developers.ledger.com/docs/device-app/references/tools#speculos)