### PR TITLE
Clarify cryptography requirements

### DIFF
--- a/pages/docs/device-app/integration/requirements/cryptography.mdx
+++ b/pages/docs/device-app/integration/requirements/cryptography.mdx
@@ -21,11 +21,11 @@ Even in encrypted form, those secrets **must not** be stored outside of the devi
 
 ### Avoid blindly signing data
 
-**You should never allow signing of any attacker-controlled message unless it has been verified for structural validity. Importantly, you should never sign a message that might be a hash of transaction.**
+**You must never allow signing of any attacker-controlled message unless it has been verified for structural validity. Importantly, you must never sign a message that might be a hash of transaction.**
 
 Rationale: If you allow an attacker to blindly sign a message, it can easily supply a hash of a valid transaction. Your signature could then be used to send an unauthorized transaction.
 
-If you want to sign user-supplied "personal" messages, prefix them with a fixed string (which shouldn't be a valid transaction prefix). It is also a good practice to include message length in the text to be signed. Ledger-app-eth has a good example in function `handleSignPersonalMessage`. Note that sometimes cryptocurrencies have a standardized way of signing such personal messages and in that case you should use the approved scheme.
+If you want to sign user-supplied "personal" messages, you **must** prefix them with a fixed string (which shouldn't be a valid transaction prefix). It is also a good practice to include message length in the text to be signed. Ledger-app-eth has a good example in function `handleSignPersonalMessage`. Note that sometimes cryptocurrencies have a standardized way of signing such personal messages and in that case you should use the approved scheme.
 
 Warning: If you allow signing untrusted hashes (while displaying a prompt to the user), be aware that
 
@@ -69,7 +69,7 @@ Rationale: the exception mechanism is not standard C, and is difficult to use, p
 
 ### Private Key Management
 
-**You should minimize the code that works with private (ECDSA, RSA, etc.) or secret (HMAC, AES, etc.) keys.** Importantly, you should always **clear the memory** after you use these keys. That includes key data and key objects.
+**You should minimize the code that works with private (ECDSA, RSA, etc.) or secret (HMAC, AES, etc.) keys.** Importantly, you **must always clear the memory** after you use these keys. That includes key data and key objects.
 
 Leaving parts of private or secret keys lying around in memory is not a security issue on its own because there is no easy way to extract the RAM content on the chip. If a key is left in RAM by an app, another app will not be able to access it.
 


### PR DESCRIPTION
This PR clarifies the cryptography requirements by using the term "must" instead of "should" whenever a behavior is mandatory.