### PR TITLE
fix/dev-track

### DIFF
--- a/pages/docs/_meta.js
+++ b/pages/docs/_meta.js
@@ -1,8 +1,4 @@
 export default {
-  'dev-tracks': {
-        type: 'page',
-        title: 'Dev tracks'
-      },
   'news': {
         type: 'page',
         title: "What's new?"


### PR DESCRIPTION
Before this modification this error occurred, upon 'pnpm dev':

Error: Validation of "_meta" file has failed.
The field key "dev-tracks" in `_meta` file refers to a page that cannot be found, remove this key from "_meta" file.