### PR TITLE
Fix useSignMessage example

### DIFF
--- a/pages/docs/ledger-live/discover/integration/wallet-api/react/hooks/useSignMessage.mdx
+++ b/pages/docs/ledger-live/discover/integration/wallet-api/react/hooks/useSignMessage.mdx
@@ -39,10 +39,9 @@ function App() {
   }, [requestAccount]);
 
   const handleSignMessage = async () => {
-    if (account) {
-      const signedMessage = await signMessage(account.id,  Buffer.from("Hello, Ledger!"));
-      setResponse(signedMessage);
-    }
+    if (!account) return;
+    const signedMessage = await signMessage(account.id,  Buffer.from("Hello, Ledger!"));
+    setResponse(signedMessage);
   };
 
   return (

--- a/pages/docs/ledger-live/discover/integration/wallet-api/react/hooks/useSignMessage.mdx
+++ b/pages/docs/ledger-live/discover/integration/wallet-api/react/hooks/useSignMessage.mdx
@@ -40,7 +40,7 @@ function App() {
 
   const handleSignMessage = async () => {
     if (account) {
-      const signedMessage = await signMessage(account.id, "Hello, Ledger!");
+      const signedMessage = await signMessage(account.id,  Buffer.from("Hello, Ledger!"));
       setResponse(signedMessage);
     }
   };

--- a/pages/docs/ledger-live/discover/integration/wallet-api/react/hooks/useSignMessage.mdx
+++ b/pages/docs/ledger-live/discover/integration/wallet-api/react/hooks/useSignMessage.mdx
@@ -30,8 +30,7 @@ import {
 
 function App() {
   const { requestAccount, account } = useRequestAccount();
-  const { signMessage } = useSignMessage();
-  const [response, setResponse] = useState(null);
+  const { signMessage, signature } = useSignMessage();
 
   // Prompt the user to select an account on component mount
   useEffect(() => {
@@ -40,8 +39,7 @@ function App() {
 
   const handleSignMessage = async () => {
     if (!account) return;
-    const signedMessage = await signMessage(account.id,  Buffer.from("Hello, Ledger!"));
-    setResponse(signedMessage);
+    await signMessage(account.id,  Buffer.from("Hello, Ledger!"));
   };
 
   return (
@@ -49,10 +47,10 @@ function App() {
       <h1>Test Live App - Services Kit</h1>
       <div className="card">
         <button onClick={handleSignMessage}>Sign Message</button>
-        {response && (
+        {signature && (
           <div>
             <h3>Signed Message:</h3>
-            <p>{response}</p>
+            <p>{signature}</p>
           </div>
         )}
       </div>


### PR DESCRIPTION
This pull request updates the `useSignMessage` hook usage in the `useSignMessage.mdx` file to improve the handling of message signing and simplify the code. 
The most important changes include replacing the `response` state with the `signature` property directly from the hook because signMessage function return void dans not the signed message
Improvements to message signing:

