### PR TITLE
Bug / Typo and incorrect casing in npm package names for DMK, DSE, DSB, DSS

### DIFF
--- a/pages/docs/device-interaction/getting-started.mdx
+++ b/pages/docs/device-interaction/getting-started.mdx
@@ -39,10 +39,10 @@ Here you can found a summary of all the libraries that are composing the DMK
 
 | Library                | NPM                                                                                                            | Version |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------- | ------- |
-| Device Management Kit  | [@LedgerHQ/device-mangement-kit](https://www.npmjs.com/package/@ledgerhq/device-management-kit)                | 0.7.0   |
-| Device Signer Ethereum | [@LedgerHQ/device-signer-kit-ethereum](https://www.npmjs.com/package/@ledgerhq/device-signer-kit-ethereum)     | 1.4.0   |
-| Device Signer Bitcoin  | [@LedgerHQ/device-signer-kit-bitcoin](https://www.npmjs.com/package/@ledgerhq/device-signer-kit-bitcoin)       | 1.0.0   |
-| Device Signer Solana   | [@LedgerHQ/device-signer-kit-solana](https://www.npmjs.com/package/@ledgerhq/device-signer-kit-solana)         | 1.1.0   |
+| Device Management Kit  | [@ledgerhq/device-mangement-kit](https://www.npmjs.com/package/@ledgerhq/device-management-kit)                | 0.7.0   |
+| Device Signer Ethereum | [@ledgerhq/device-signer-kit-ethereum](https://www.npmjs.com/package/@ledgerhq/device-signer-kit-ethereum)     | 1.4.0   |
+| Device Signer Bitcoin  | [@ledgerhq/device-signer-kit-bitcoin](https://www.npmjs.com/package/@ledgerhq/device-signer-kit-bitcoin)       | 1.0.0   |
+| Device Signer Solana   | [@ledgerhq/device-signer-kit-solana](https://www.npmjs.com/package/@ledgerhq/device-signer-kit-solana)         | 1.1.0   |
 | Context Module         | [@ledgerhq/context-module](https://www.npmjs.com/package/@ledgerhq/context-module)                             | 1.4.0   |
 | WebHidTransport        | [@ledgerhq/device-transport-kit-web-hid](https://www.npmjs.com/package/@ledgerhq/device-transport-kit-web-hid) | 1.1.0   |
 | WebBleTransport        | [@ledgerhq/device-transport-kit-web-ble](https://www.npmjs.com/package/@ledgerhq/device-transport-kit-web-ble) | 1.1.0   |

--- a/pages/docs/device-interaction/getting-started.mdx
+++ b/pages/docs/device-interaction/getting-started.mdx
@@ -39,7 +39,7 @@ Here you can found a summary of all the libraries that are composing the DMK
 
 | Library                | NPM                                                                                                            | Version |
 | ---------------------- | -------------------------------------------------------------------------------------------------------------- | ------- |
-| Device Management Kit  | [@ledgerhq/device-mangement-kit](https://www.npmjs.com/package/@ledgerhq/device-management-kit)                | 0.7.0   |
+| Device Management Kit  | [@ledgerhq/device-management-kit](https://www.npmjs.com/package/@ledgerhq/device-management-kit)               | 0.7.0   |
 | Device Signer Ethereum | [@ledgerhq/device-signer-kit-ethereum](https://www.npmjs.com/package/@ledgerhq/device-signer-kit-ethereum)     | 1.4.0   |
 | Device Signer Bitcoin  | [@ledgerhq/device-signer-kit-bitcoin](https://www.npmjs.com/package/@ledgerhq/device-signer-kit-bitcoin)       | 1.0.0   |
 | Device Signer Solana   | [@ledgerhq/device-signer-kit-solana](https://www.npmjs.com/package/@ledgerhq/device-signer-kit-solana)         | 1.1.0   |


### PR DESCRIPTION
This PR fixes the following issues in the docs:

- Fixed: Corrected typo in the Device Management Kit package name - @ledgerhq/device-**management**-kit (missing **a**)
- Fixed: Normalized package names to lowercase (@LedgerHQ - @ledgerhq) for consistency

Even though these packages live under the correct scoped namespace, incorrect names could potentially mislead users or open the door for typo-squatting (e.g. if a similarly named malicious package is published). This fix ensures clarity and mitigates that risk 🛡️ 