### PR TITLE
Bug / Incorrect transport factory imports for BLE and USB

### DIFF
--- a/pages/docs/device-interaction/beginner/ble_flex_stax.mdx
+++ b/pages/docs/device-interaction/beginner/ble_flex_stax.mdx
@@ -11,11 +11,11 @@ Device Management Kit: v0.4.0 (and later)
 ```typescript
 import { DeviceManagementKitBuilder } from "@ledgerhq/device-management-kit";
 import { webBleTransportFactory } from "@ledgerhq/device-transport-kit-web-ble";
-import { webUsbTransportFactory } from "@ledgerhq/device-transport-kit-web-hid";
+import { webHidTransportFactory } from "@ledgerhq/device-transport-kit-web-hid";
 
 const dmk = new DeviceManagementKitBuilder()
   .addTransport(webBleTransportFactory)
-  .addTransport(webUsbTransportFactory)
+  .addTransport(webHidTransportFactory)
   .build();
 ```
 

--- a/pages/docs/device-interaction/beginner/ble_flex_stax.mdx
+++ b/pages/docs/device-interaction/beginner/ble_flex_stax.mdx
@@ -11,13 +11,11 @@ Device Management Kit: v0.4.0 (and later)
 ```typescript
 import { DeviceManagementKitBuilder } from "@ledgerhq/device-management-kit";
 import { webBleTransportFactory } from "@ledgerhq/device-transport-kit-web-ble";
-import {
-  WebUsbTransportFactory,
-} from "@ledgerhq/device-transport-kit-web";
+import { webUsbTransportFactory } from "@ledgerhq/device-transport-kit-web-hid";
 
 const dmk = new DeviceManagementKitBuilder()
   .addTransport(webBleTransportFactory)
-  .addTransport(WebUsbTransportFactory)
+  .addTransport(webUsbTransportFactory)
   .build();
 ```
 

--- a/pages/docs/device-interaction/beginner/ble_flex_stax.mdx
+++ b/pages/docs/device-interaction/beginner/ble_flex_stax.mdx
@@ -10,8 +10,8 @@ Device Management Kit: v0.4.0 (and later)
 
 ```typescript
 import { DeviceManagementKitBuilder } from "@ledgerhq/device-management-kit";
+import { webBleTransportFactory } from "@ledgerhq/device-transport-kit-web-ble";
 import {
-  webBleTransportFactory,
   WebUsbTransportFactory,
 } from "@ledgerhq/device-transport-kit-web";
 


### PR DESCRIPTION
This PR fixes the following issues in the docs:

- Fixed: Incorrect import for `webBleTransportFactory`, should be imported from `@ledgerhq/device-transport-kit-web-ble` package
- Fixed: Use `webHidTransportFactory`, imported from `@ledgerhq/device-transport-kit-web-hid` instead of, I assume, a legacy `WebUsbTransportFactory` instance from a package that doesn't exist in npm (`@ledgerhq/device-transport-kit-web`).